### PR TITLE
Add GradientFlow entry point and tests

### DIFF
--- a/Sources/GradientFlow/GradientFlow.swift
+++ b/Sources/GradientFlow/GradientFlow.swift
@@ -1,2 +1,138 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
+// GradientFlow.swift
+// GradientFlow SDK - Entry Point
+
+import UIKit
+
+/// Main namespace for the GradientFlow SDK
+public struct GradientFlow {
+    
+    /// SDK version
+    public static let version = "1.0.0"
+    
+    /// SDK name
+    public static let name = "GradientFlow"
+    
+    // MARK: - Quick Creation
+    
+    /// Quickly create a gradient text label
+    /// - Returns: A new GradientTextLabel instance
+    @MainActor
+    public static func createLabel() -> GradientTextLabel {
+        return GradientTextLabel.create()
+    }
+    
+    /// Quickly create an animated gradient text label
+    /// - Parameters:
+    ///   - text: The text to display
+    ///   - colors: An array of gradient colors
+    /// - Returns: A configured GradientTextLabel instance
+    @MainActor public static func createAnimatedLabel(
+        text: String,
+        colors: [UIColor]
+    ) -> GradientTextLabel {
+        return GradientTextLabel.create()
+            .setText(text)
+            .setColors(colors)
+            .setAnimated(true)
+    }
+    
+    // MARK: - Preset Colors
+    
+    /// Predefined color presets
+    public struct ColorPresets {
+        
+        /// Cool green-blue (default)
+        public static let coolMint: [UIColor] = [
+            UIColor(red: 0.2, green: 0.8, blue: 0.5, alpha: 1.0),
+            UIColor(red: 0.2, green: 0.6, blue: 1.0, alpha: 1.0)
+        ]
+        
+        /// Warm orange-pink
+        public static let warmSunset: [UIColor] = [
+            UIColor(red: 1.0, green: 0.6, blue: 0.2, alpha: 1.0),
+            UIColor(red: 1.0, green: 0.3, blue: 0.5, alpha: 1.0)
+        ]
+        
+        /// Purple-pink
+        public static let purpleDream: [UIColor] = [
+            UIColor(red: 0.6, green: 0.3, blue: 1.0, alpha: 1.0),
+            UIColor(red: 1.0, green: 0.4, blue: 0.7, alpha: 1.0)
+        ]
+        
+        /// Neon blue-purple
+        public static let neonNight: [UIColor] = [
+            UIColor(red: 0.2, green: 0.4, blue: 1.0, alpha: 1.0),
+            UIColor(red: 0.8, green: 0.2, blue: 1.0, alpha: 1.0)
+        ]
+        
+        /// Green-yellow
+        public static let freshGreen: [UIColor] = [
+            UIColor(red: 0.2, green: 0.9, blue: 0.3, alpha: 1.0),
+            UIColor(red: 0.9, green: 0.9, blue: 0.2, alpha: 1.0)
+        ]
+        
+        /// Rainbow
+        public static let rainbow: [UIColor] = [
+            .systemRed,
+            .systemOrange,
+            .systemYellow,
+            .systemGreen,
+            .systemBlue,
+            .systemPurple
+        ]
+    }
+    
+    // MARK: - Configuration
+    
+    /// Global default configuration
+    public struct Configuration {
+        
+        /// Default font size
+        public static let defaultFontSize: CGFloat = 24
+        
+        /// Default font weight
+        public static let defaultFontWeight: UIFont.Weight = .bold
+        
+        /// Default animation duration
+        public static let defaultAnimationDuration: TimeInterval = 4.0
+        
+        /// Default gradient colors
+        public static let defaultColors: [UIColor] = ColorPresets.coolMint
+        
+        /// Whether animation is enabled by default
+        public static let defaultIsAnimated: Bool = true
+    }
+}
+
+// MARK: - Convenience Extensions
+
+extension GradientTextLabel {
+    
+    /// Apply a preset color set
+    /// - Parameter preset: A color preset
+    /// - Returns: Self (for chaining)
+    @discardableResult
+    public func setColorPreset(_ preset: [UIColor]) -> Self {
+        return setColors(preset)
+    }
+}
+
+//// 1. Basic creation
+//let label = GradientFlow.createLabel()
+//
+//// 2. Quick creation
+//let label = GradientFlow.createAnimatedLabel(
+//    text: "Hello",
+//    colors: GradientFlow.ColorPresets.purpleDream
+//)
+//
+//// 3. Using a preset
+//let label = GradientTextLabel.create()
+//    .setText("Rainbow!")
+//    .setColorPreset(GradientFlow.ColorPresets.rainbow)
+//
+//// 4. Changing global defaults
+//GradientFlow.Configuration.defaultFontSize = 32
+//GradientFlow.Configuration.defaultColors = GradientFlow.ColorPresets.neonNight

--- a/Tests/GradientFlowTests/GradientFlowTests.swift
+++ b/Tests/GradientFlowTests/GradientFlowTests.swift
@@ -2,11 +2,130 @@ import XCTest
 @testable import GradientFlow
 
 final class GradientFlowTests: XCTestCase {
-    func testExample() throws {
-        // XCTest Documentation
-        // https://developer.apple.com/documentation/xctest
 
-        // Defining Test Cases and Test Methods
-        // https://developer.apple.com/documentation/xctest/defining_test_cases_and_test_methods
+    // MARK: - GradientFlow Entry Point
+
+    @MainActor
+    func test_createLabel_returnsGradientTextLabel() {
+        let label = GradientFlow.createLabel()
+        XCTAssertNotNil(label)
+        XCTAssertTrue(type(of: label) == GradientTextLabel.self)
+    }
+
+    @MainActor
+    func test_createAnimatedLabel_setsTextColorsAndAnimationFlag() {
+        let colors = GradientFlow.ColorPresets.purpleDream
+
+        let label = GradientFlow.createAnimatedLabel(text: "Hello", colors: colors)
+
+        XCTAssertEqual(label.text, "Hello")
+        XCTAssertEqual(label.colors.count, colors.count)
+        XCTAssertEqual(label.colors, colors)
+        XCTAssertTrue(label.isAnimated)
+    }
+
+    // MARK: - Fluent API (Chaining)
+
+    @MainActor
+    func test_fluentAPI_setsProperties() {
+        let label = GradientTextLabel.create()
+            .setText("Rainbow!")
+            .setFontSize(32)
+            .setFontWeight(.semibold)
+            .setGradientDirection(.topToBottom)
+            .setAnimated(false)
+            .setAnimationDirection(.bottomToTop)
+            .setAnimationDuration(2.5)
+
+        XCTAssertEqual(label.text, "Rainbow!")
+        XCTAssertEqual(label.fontSize, 32)
+        XCTAssertEqual(label.fontWeight, .semibold)
+        XCTAssertEqual(label.gradientDirection, .topToBottom)
+        XCTAssertFalse(label.isAnimated)
+        XCTAssertEqual(label.animationDirection, .bottomToTop)
+        XCTAssertEqual(label.animationDuration, 2.5, accuracy: 0.0001)
+    }
+
+    // MARK: - Presets
+
+    @MainActor
+    func test_setColorPreset_appliesColors() {
+        let preset = GradientFlow.ColorPresets.rainbow
+
+        let label = GradientTextLabel.create()
+            .setColorPreset(preset)
+
+        XCTAssertEqual(label.colors, preset)
+    }
+
+    // MARK: - AnimationDirection
+
+    func test_animationDirection_keyPath_isCorrect() {
+        XCTAssertEqual(AnimationDirection.leftToRight.keyPath, "x")
+        XCTAssertEqual(AnimationDirection.rightToLeft.keyPath, "x")
+        XCTAssertEqual(AnimationDirection.topToBottom.keyPath, "y")
+        XCTAssertEqual(AnimationDirection.bottomToTop.keyPath, "y")
+    }
+
+    // MARK: - Gradient Layer / Mask Wiring
+
+    @MainActor
+    func test_layoutSubviews_setsMaskAndGradientFrame() {
+        let label = GradientTextLabel()
+        label.frame = CGRect(x: 0, y: 0, width: 120, height: 40)
+
+        // Trigger a layout pass so layoutSubviews() runs.
+        label.layoutIfNeeded()
+
+        // The view should have a mask layer (CATextLayer) applied.
+        XCTAssertNotNil(label.layer.mask)
+
+        // The gradient layer frame should be non-zero after layout.
+        XCTAssertGreaterThan(label.gradientLayer.frame.width, 0)
+        XCTAssertGreaterThan(label.gradientLayer.frame.height, 0)
+    }
+
+    @MainActor
+    func test_whenAnimatedTrue_animationIsAddedToGradientLayer() {
+        let label = GradientTextLabel()
+        label.frame = CGRect(x: 0, y: 0, width: 120, height: 40)
+        label.isAnimated = true
+
+        // layoutSubviews() should start the animation when isAnimated is true.
+        label.layoutIfNeeded()
+
+        // Verify the animation is registered on the gradient layer.
+        let keys = label.gradientLayer.animationKeys() ?? []
+        XCTAssertTrue(keys.contains("gradientAnimation"))
+    }
+
+    @MainActor
+    func test_whenAnimatedFalse_animationIsRemovedFromGradientLayer() {
+        let label = GradientTextLabel()
+        label.frame = CGRect(x: 0, y: 0, width: 120, height: 40)
+        label.isAnimated = true
+        label.layoutIfNeeded()
+
+        // Turning off animation should remove it from the gradient layer.
+        label.isAnimated = false
+
+        let keys = label.gradientLayer.animationKeys() ?? []
+        XCTAssertFalse(keys.contains("gradientAnimation"))
+    }
+
+    // MARK: - Gradient Direction Start/End Points
+
+    @MainActor
+    func test_gradientDirection_updatesStartEndPoints() {
+        let label = GradientTextLabel()
+        label.frame = CGRect(x: 0, y: 0, width: 100, height: 30)
+
+        label.gradientDirection = .leftToRight
+        XCTAssertEqual(label.gradientLayer.startPoint, CGPoint(x: 0, y: 0.5))
+        XCTAssertEqual(label.gradientLayer.endPoint, CGPoint(x: 1, y: 0.5))
+
+        label.gradientDirection = .topToBottom
+        XCTAssertEqual(label.gradientLayer.startPoint, CGPoint(x: 0.5, y: 0))
+        XCTAssertEqual(label.gradientLayer.endPoint, CGPoint(x: 0.5, y: 1))
     }
 }


### PR DESCRIPTION
## Related Issue
1. Add XCTest suite for GradientFlow #5

## Motivation
As GradientFlow grew, core rendering/animation logic started to mix with convenience APIs, making responsibilities less clear and harder to maintain. This PR clarifies the SDK surface by adding a single entry point and improves regression safety with tests.

## Modifications
- Added GradientFlow SDK entry point (metadata + quick creation APIs)
    - createLabel(), createAnimatedLabel(text:colors:)
- Added presets and global defaults
    - ColorPresets, Configuration
 - Added a convenience extension on GradientTextLabel
     - setColorPreset(_:)
  - Added GradientFlowTests covering entry point, fluent chaining, presets, and core layer wiring (mask/gradient frame/animation)

## Result
GradientFlow is easier to discover and use via a clear entry point, with improved confidence through automated tests.

## Test Plan 
- Built the project successfully
    - Ran unit tests: GradientFlowTests
    - Verified creation/config, preset application, keyPath mapping
    - Verified mask/gradient frame setup on layout
    - Verified animation add/remove when toggling isAnimated
